### PR TITLE
Fix regex rule to preserve function call parentheses

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/RegularExpressions.Transformer.HasuraSQLSimplifier/issues/8
+Your prepared branch: issue-8-381c487b
+Your prepared working directory: /tmp/gh-issue-solver-1757790441999
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/RegularExpressions.Transformer.HasuraSQLSimplifier/issues/8
-Your prepared branch: issue-8-381c487b
-Your prepared working directory: /tmp/gh-issue-solver-1757790441999
-
-Proceed.

--- a/csharp/Platform.RegularExpressions.Transformer.HasuraSQLSimplifier.Tests/HasuraSQLSimplifierTransformerTests.cs
+++ b/csharp/Platform.RegularExpressions.Transformer.HasuraSQLSimplifier.Tests/HasuraSQLSimplifierTransformerTests.cs
@@ -14,6 +14,28 @@ namespace Platform.RegularExpressions.Transformer.HasuraSQLSimplifier.Tests
         }
 
         [Fact]
+        public void FunctionCallsPreservedTest()
+        {
+            var transformer = new HasuraSQLSimplifierTransformer();
+
+            // Test that function calls with quoted parameters are preserved
+            Assert.Equal("bool_or('true')", transformer.Transform("bool_or('true')"));
+            Assert.Equal("count('items')", transformer.Transform("count('items')"));
+            Assert.Equal("sum('values')", transformer.Transform("sum('values')"));
+            Assert.Equal("bool_and('false')", transformer.Transform("bool_and('false')"));
+            Assert.Equal("max('column')", transformer.Transform("max('column')"));
+            Assert.Equal("min('column')", transformer.Transform("min('column')"));
+            
+            // Test that standalone quoted strings in parentheses are still simplified
+            Assert.Equal("'quoted_string'", transformer.Transform("('quoted_string')"));
+            Assert.Equal("'describe'", transformer.Transform("('describe')"));
+            
+            // Test mixed cases - function calls preserved, standalone quoted strings simplified
+            Assert.Equal("SELECT bool_or('active') FROM table WHERE 'condition'", 
+                        transformer.Transform("SELECT bool_or('active') FROM table WHERE ('condition')"));
+        }
+
+        [Fact]
         public void BasicRequestTest()
         {
             var original = @"SELECT

--- a/csharp/Platform.RegularExpressions.Transformer.HasuraSQLSimplifier/HasuraSQLSimplifierTransformer.cs
+++ b/csharp/Platform.RegularExpressions.Transformer.HasuraSQLSimplifier/HasuraSQLSimplifierTransformer.cs
@@ -27,7 +27,8 @@ namespace Platform.RegularExpressions.Transformer.HasuraSQLSimplifier
             (new Regex(@"<span class=""[^""]*"">([^<>]*)<\/span>"), "$1", 0),
             // ('describe')
             // 'describe'
-            (new Regex(@"\([\s\n]*('[^']+')[\s\n]*\)"), "$1", int.MaxValue),
+            // But preserve function calls like bool_or('true')
+            (new Regex(@"(?<!\w)\([\s\n]*('[^']+')[\s\n]*\)"), "$1", int.MaxValue),
             // AND ('true' AND 'true')
             //
             (new Regex(@"[\s\n]*AND[\s\n]*\([\s\n]*'true'[\s\n]*AND[\s\n]*'true'[\s\n]*\)"), "", 0),

--- a/experiments/Program.cs
+++ b/experiments/Program.cs
@@ -1,0 +1,30 @@
+using Platform.RegularExpressions.Transformer.HasuraSQLSimplifier;
+
+var transformer = new HasuraSQLSimplifierTransformer();
+
+// Test case from the issue
+var testInput = "bool_or('true')";
+var result = transformer.Transform(testInput);
+
+Console.WriteLine($"Input:  {testInput}");
+Console.WriteLine($"Output: {result}");
+Console.WriteLine($"Expected: {testInput}"); // Function calls should remain unchanged
+Console.WriteLine($"Issue: {result != testInput}");
+
+// Additional test cases
+string[] testCases = {
+    "bool_or('true')",
+    "count('items')",
+    "sum('values')",
+    "bool_and('false')",
+    "('quoted_string')",  // This should be simplified to 'quoted_string'
+    "max('column')",
+    "min('column')"
+};
+
+Console.WriteLine("\n=== All Test Cases ===");
+foreach (var testCase in testCases)
+{
+    var output = transformer.Transform(testCase);
+    Console.WriteLine($"{testCase} -> {output}");
+}

--- a/experiments/experiments.csproj
+++ b/experiments/experiments.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../csharp/Platform.RegularExpressions.Transformer.HasuraSQLSimplifier/Platform.RegularExpressions.Transformer.HasuraSQLSimplifier.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/experiments/test_function_issue.cs
+++ b/experiments/test_function_issue.cs
@@ -1,0 +1,40 @@
+using Platform.RegularExpressions.Transformer.HasuraSQLSimplifier;
+using System;
+
+namespace Experiments
+{
+    class TestFunctionIssue
+    {
+        static void Main(string[] args)
+        {
+            var transformer = new HasuraSQLSimplifierTransformer();
+            
+            // Test case from the issue
+            var testInput = "bool_or('true')";
+            var result = transformer.Transform(testInput);
+            
+            Console.WriteLine($"Input:  {testInput}");
+            Console.WriteLine($"Output: {result}");
+            Console.WriteLine($"Expected: {testInput}"); // Function calls should remain unchanged
+            Console.WriteLine($"Issue: {result != testInput}");
+            
+            // Additional test cases
+            string[] testCases = {
+                "bool_or('true')",
+                "count('items')",
+                "sum('values')",
+                "bool_and('false')",
+                "('quoted_string')",  // This should be simplified to 'quoted_string'
+                "max('column')",
+                "min('column')"
+            };
+            
+            Console.WriteLine("\n=== All Test Cases ===");
+            foreach (var testCase in testCases)
+            {
+                var output = transformer.Transform(testCase);
+                Console.WriteLine($"{testCase} -> {output}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Fixed the regex rule that was incorrectly removing parentheses from function calls like `bool_or('true')`
- Modified the regex pattern to use negative lookbehind `(?<!\w)` to prevent matching parentheses that follow word characters (function names)
- Function calls are now preserved correctly while standalone quoted strings in parentheses continue to be simplified as intended
- Added comprehensive unit tests to verify the fix and prevent regression

## Technical Details

The issue was in line 30 of `HasuraSQLSimplifierTransformer.cs` where the regex pattern:
```regex
\([\s\n]*('[^']+')[\s\n]*\)
```

Was changed to:
```regex
(?<!\w)\([\s\n]*('[^']+')[\s\n]*\)
```

The negative lookbehind `(?<!\w)` ensures that the opening parenthesis is not preceded by a word character, which prevents matching function calls while still allowing the simplification of standalone quoted expressions.

## Test Results

- All existing tests pass ✅
- New test `FunctionCallsPreservedTest` added to verify:
  - Function calls like `bool_or('true')`, `count('items')` are preserved
  - Standalone quoted strings like `('describe')` are still simplified to `'describe'`
  - Mixed scenarios work correctly

## Examples

### Before (❌ Incorrect)
```sql
bool_or('true') -> bool_or'true'  -- Missing parentheses!
```

### After (✅ Correct)
```sql
bool_or('true') -> bool_or('true')  -- Function call preserved
('describe') -> 'describe'          -- Standalone quoted string still simplified
```

Fixes #8

🤖 Generated with [Claude Code](https://claude.ai/code)