### PR TITLE
Improve HTML tag removal with code tag support and whitespace trimming

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/RegularExpressions.Transformer.HasuraSQLSimplifier/issues/7
-Your prepared branch: issue-7-a650218e
-Your prepared working directory: /tmp/gh-issue-solver-1757791815930
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/RegularExpressions.Transformer.HasuraSQLSimplifier/issues/7
+Your prepared branch: issue-7-a650218e
+Your prepared working directory: /tmp/gh-issue-solver-1757791815930
+
+Proceed.

--- a/csharp/Platform.RegularExpressions.Transformer.HasuraSQLSimplifier.Tests/HasuraSQLSimplifierTransformerTests.cs
+++ b/csharp/Platform.RegularExpressions.Transformer.HasuraSQLSimplifier.Tests/HasuraSQLSimplifierTransformerTests.cs
@@ -14,6 +14,70 @@ namespace Platform.RegularExpressions.Transformer.HasuraSQLSimplifier.Tests
         }
 
         [Fact]
+        public void SpanTagRemovalTest()
+        {
+            var transformer = new HasuraSQLSimplifierTransformer();
+            
+            // Test basic span tag removal
+            var input1 = @"SELECT <span class=""highlight"">column_name</span> FROM table";
+            var expected1 = @"SELECT column_name FROM table";
+            var actual1 = transformer.Transform(input1);
+            Assert.Equal(expected1, actual1);
+            
+            // Test span tag with extra whitespace removal
+            var input2 = @"SELECT <span class=""highlight"">  column_name  </span> FROM table";
+            var expected2 = @"SELECT column_name FROM table";
+            var actual2 = transformer.Transform(input2);
+            Assert.Equal(expected2, actual2);
+            
+            // Test span tag with newlines and tabs
+            var input3 = @"SELECT <span class=""highlight"">
+                column_name
+            </span> FROM table";
+            var expected3 = @"SELECT column_name FROM table";
+            var actual3 = transformer.Transform(input3);
+            Assert.Equal(expected3, actual3);
+        }
+
+        [Fact]
+        public void CodeTagRemovalTest()
+        {
+            var transformer = new HasuraSQLSimplifierTransformer();
+            
+            // Test basic code tag removal
+            var input1 = @"SELECT <code>column_name</code> FROM table";
+            var expected1 = @"SELECT column_name FROM table";
+            var actual1 = transformer.Transform(input1);
+            Assert.Equal(expected1, actual1);
+            
+            // Test code tag with extra whitespace removal
+            var input2 = @"SELECT <code>  column_name  </code> FROM table";
+            var expected2 = @"SELECT column_name FROM table";
+            var actual2 = transformer.Transform(input2);
+            Assert.Equal(expected2, actual2);
+            
+            // Test code tag with newlines and tabs
+            var input3 = @"SELECT <code>
+                column_name
+            </code> FROM table";
+            var expected3 = @"SELECT column_name FROM table";
+            var actual3 = transformer.Transform(input3);
+            Assert.Equal(expected3, actual3);
+        }
+
+        [Fact]
+        public void MixedHtmlTagsTest()
+        {
+            var transformer = new HasuraSQLSimplifierTransformer();
+            
+            // Test mixed span and code tags
+            var input = @"SELECT <span class=""highlight"">  table_name  </span>.<code>  column_name  </code> FROM <span class=""table"">another_table</span>";
+            var expected = @"SELECT table_name.column_name FROM another_table";
+            var actual = transformer.Transform(input);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
         public void BasicRequestTest()
         {
             var original = @"SELECT

--- a/csharp/Platform.RegularExpressions.Transformer.HasuraSQLSimplifier/HasuraSQLSimplifierTransformer.cs
+++ b/csharp/Platform.RegularExpressions.Transformer.HasuraSQLSimplifier/HasuraSQLSimplifierTransformer.cs
@@ -23,8 +23,10 @@ namespace Platform.RegularExpressions.Transformer.HasuraSQLSimplifier
         /// </summary>
         public static readonly IList<ISubstitutionRule> DefaultRules = new List<SubstitutionRule>
         {
-            // HTML clean up
-            (new Regex(@"<span class=""[^""]*"">([^<>]*)<\/span>"), "$1", 0),
+            // HTML clean up - span tags with whitespace trimming
+            (new Regex(@"<span class=""[^""]*"">\s*([^<>]*?)\s*<\/span>"), "$1", 0),
+            // HTML clean up - code tags with whitespace trimming
+            (new Regex(@"<code>\s*([^<>]*?)\s*<\/code>"), "$1", 0),
             // ('describe')
             // 'describe'
             (new Regex(@"\([\s\n]*('[^']+')[\s\n]*\)"), "$1", int.MaxValue),

--- a/experiments/test_html_removal.cs
+++ b/experiments/test_html_removal.cs
@@ -1,0 +1,46 @@
+using System;
+using Platform.RegularExpressions.Transformer.HasuraSQLSimplifier;
+
+class TestHTMLRemoval
+{
+    static void Main(string[] args)
+    {
+        var transformer = new HasuraSQLSimplifierTransformer();
+        
+        // Current span tag support
+        string spanTest = @"SELECT <span class=""highlight"">column_name</span> FROM table";
+        Console.WriteLine("Span test:");
+        Console.WriteLine("Input: " + spanTest);
+        Console.WriteLine("Output: " + transformer.Transform(spanTest));
+        Console.WriteLine();
+        
+        // Code tag support (should be added)
+        string codeTest = @"SELECT <code>column_name</code> FROM table";
+        Console.WriteLine("Code test:");
+        Console.WriteLine("Input: " + codeTest);
+        Console.WriteLine("Output: " + transformer.Transform(codeTest));
+        Console.WriteLine();
+        
+        // Test with inner whitespace
+        string whitespaceTest1 = @"SELECT <span class=""highlight"">  column_name  </span> FROM table";
+        Console.WriteLine("Whitespace test 1 (span with spaces):");
+        Console.WriteLine("Input: " + whitespaceTest1);
+        Console.WriteLine("Output: " + transformer.Transform(whitespaceTest1));
+        Console.WriteLine();
+        
+        string whitespaceTest2 = @"SELECT <code>  column_name  </code> FROM table";
+        Console.WriteLine("Whitespace test 2 (code with spaces):");
+        Console.WriteLine("Input: " + whitespaceTest2);
+        Console.WriteLine("Output: " + transformer.Transform(whitespaceTest2));
+        Console.WriteLine();
+        
+        // Test with newlines and tabs
+        string whitespaceTest3 = @"SELECT <span class=""highlight"">
+            column_name
+        </span> FROM table";
+        Console.WriteLine("Whitespace test 3 (span with newlines):");
+        Console.WriteLine("Input: " + whitespaceTest3);
+        Console.WriteLine("Output: " + transformer.Transform(whitespaceTest3));
+        Console.WriteLine();
+    }
+}

--- a/experiments/test_program.cs
+++ b/experiments/test_program.cs
@@ -1,0 +1,42 @@
+using System;
+using Platform.RegularExpressions.Transformer.HasuraSQLSimplifier;
+
+class Program
+{
+    static void Main()
+    {
+        var transformer = new HasuraSQLSimplifierTransformer();
+        
+        Console.WriteLine("=== HTML Tag Removal Tests ===");
+        
+        // Test 1: Basic span tag
+        string test1 = @"SELECT <span class=""highlight"">column_name</span> FROM table";
+        Console.WriteLine($"Input:  {test1}");
+        Console.WriteLine($"Output: {transformer.Transform(test1)}");
+        Console.WriteLine();
+        
+        // Test 2: Basic code tag (new functionality)
+        string test2 = @"SELECT <code>column_name</code> FROM table";
+        Console.WriteLine($"Input:  {test2}");
+        Console.WriteLine($"Output: {transformer.Transform(test2)}");
+        Console.WriteLine();
+        
+        // Test 3: Span with whitespace trimming
+        string test3 = @"SELECT <span class=""highlight"">  column_name  </span> FROM table";
+        Console.WriteLine($"Input:  {test3}");
+        Console.WriteLine($"Output: {transformer.Transform(test3)}");
+        Console.WriteLine();
+        
+        // Test 4: Code with whitespace trimming (new functionality)
+        string test4 = @"SELECT <code>  column_name  </code> FROM table";
+        Console.WriteLine($"Input:  {test4}");
+        Console.WriteLine($"Output: {transformer.Transform(test4)}");
+        Console.WriteLine();
+        
+        // Test 5: Mixed tags
+        string test5 = @"SELECT <span class=""table"">table_name</span>.<code>  column_id  </code> FROM database";
+        Console.WriteLine($"Input:  {test5}");
+        Console.WriteLine($"Output: {transformer.Transform(test5)}");
+        Console.WriteLine();
+    }
+}


### PR DESCRIPTION
## Summary
- Add support for `<code>` tags in addition to existing `<span>` tags
- Implement whitespace trimming around tag content using non-greedy regex matching
- Update regex patterns to handle spaces, newlines, and tabs around content
- Add comprehensive tests for span tags, code tags, and mixed scenarios
- Ensure backward compatibility with existing functionality

## Changes Made
### Core Implementation
- **Enhanced span tag regex**: Updated from `([^<>]*)` to `\s*([^<>]*?)\s*` for whitespace trimming
- **Added code tag support**: New regex pattern `<code>\s*([^<>]*?)\s*<\/code>` to handle `<code>` tags
- **Non-greedy matching**: Used `*?` to ensure proper content capture with whitespace trimming

### Test Coverage
- **SpanTagRemovalTest**: Tests basic span removal, whitespace trimming, and newline handling
- **CodeTagRemovalTest**: Tests basic code tag removal, whitespace trimming, and newline handling  
- **MixedHtmlTagsTest**: Tests combination of span and code tags in single input

## Test Results
✅ All 5 tests pass (2 existing + 3 new)

## Examples
**Before:**
```sql
SELECT <span class="highlight">  column_name  </span> FROM table
SELECT <code>table_id</code> FROM database
```

**After:**
```sql
SELECT column_name FROM table
SELECT table_id FROM database
```

Fixes #7

🤖 Generated with [Claude Code](https://claude.ai/code)