### PR TITLE
Implement SQL compactification for simple queries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/RegularExpressions.Transformer.HasuraSQLSimplifier/issues/6
+Your prepared branch: issue-6-19b8a257
+Your prepared working directory: /tmp/gh-issue-solver-1757792267659
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/RegularExpressions.Transformer.HasuraSQLSimplifier/issues/6
-Your prepared branch: issue-6-19b8a257
-Your prepared working directory: /tmp/gh-issue-solver-1757792267659
-
-Proceed.

--- a/csharp/Platform.RegularExpressions.Transformer.HasuraSQLSimplifier.Tests/HasuraSQLSimplifierTransformerTests.cs
+++ b/csharp/Platform.RegularExpressions.Transformer.HasuraSQLSimplifier.Tests/HasuraSQLSimplifierTransformerTests.cs
@@ -128,5 +128,37 @@ FROM
             var actual = transformer.Transform(original);
             Assert.Equal(expected, actual);
         }
+
+        [Fact]
+        public void CompactificationTest()
+        {
+            var original = @"SELECT
+*
+FROM
+nodes
+WHERE";
+            
+            var expected = "SELECT * FROM nodes WHERE";
+            
+            var transformer = new HasuraSQLSimplifierTransformer();
+            var actual = transformer.Transform(original);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void SimpleCompactificationWithColumnsTest()
+        {
+            var original = @"SELECT
+id
+FROM
+users
+WHERE";
+            
+            var expected = "SELECT id FROM users WHERE";
+            
+            var transformer = new HasuraSQLSimplifierTransformer();
+            var actual = transformer.Transform(original);
+            Assert.Equal(expected, actual);
+        }
     }
 }

--- a/csharp/Platform.RegularExpressions.Transformer.HasuraSQLSimplifier/HasuraSQLSimplifierTransformer.cs
+++ b/csharp/Platform.RegularExpressions.Transformer.HasuraSQLSimplifier/HasuraSQLSimplifierTransformer.cs
@@ -58,6 +58,9 @@ namespace Platform.RegularExpressions.Transformer.HasuraSQLSimplifier
             // ((EXISTS (...)))
             // (EXISTS (...))
             (new Regex(@"(\W)\([\s\n]*((?!SELECT)[^\s\n()][^()]*\([^()]*\([^()]*\)[^()]*\)[^()]*?)[\s\n]*\)"), "$1$2", int.MaxValue),
+            // SQL keyword compactification for simple cases: SELECT\n*\nFROM\ntable\nWHERE -> SELECT * FROM table WHERE
+            // Only applies to simple single-word/single-char patterns to avoid breaking complex queries
+            (new Regex(@"^(SELECT)\n(\*|\w+(?:\.\w+)?(?:,\s*\w+(?:\.\w+)?)*)\nFROM\n(\w+(?:\.\w+)?)\n(WHERE|ORDER\s+BY|GROUP\s+BY|LIMIT|$)", RegexOptions.IgnoreCase | RegexOptions.Multiline), "$1 $2 FROM $3 $4", 0),
         }.Cast<ISubstitutionRule>().ToList();
 
         /// <summary>


### PR DESCRIPTION
## Summary

This PR implements SQL query compactification functionality to address issue #6. The feature transforms multi-line SQL queries into single-line format for simple cases.

### Changes

- **Added regex rule for SQL compactification**: Transforms patterns like:
  ```sql
  SELECT
  *
  FROM
  nodes
  WHERE
  ```
  into:
  ```sql
  SELECT * FROM nodes WHERE
  ```

- **Conservative approach**: The regex pattern only matches simple cases to avoid breaking complex queries that should remain multi-line for readability

- **Comprehensive tests**: Added test cases to validate:
  - Basic compactification (`SELECT * FROM nodes WHERE`)
  - Column-specific compactification (`SELECT id FROM users WHERE`) 
  - Existing functionality remains intact (all original tests pass)

### Implementation Details

The new regex pattern is:
```regex
^(SELECT)\n(\*|\w+(?:\.\w+)?(?:,\s*\w+(?:\.\w+)?)*)\nFROM\n(\w+(?:\.\w+)?)\n(WHERE|ORDER\s+BY|GROUP\s+BY|LIMIT|$)
```

This pattern:
- Uses start-of-line anchor (`^`) to ensure full control over the match
- Supports `*` or simple column names (including dot-notation like `table.column`)
- Only compacts when followed by simple table names
- Preserves line breaks for complex queries with subqueries or complex expressions

### Test Results

All tests pass:
- ✅ EmptyLineTest
- ✅ BasicRequestTest (existing functionality preserved)  
- ✅ CompactificationTest (new: `SELECT * FROM nodes WHERE`)
- ✅ SimpleCompactificationWithColumnsTest (new: `SELECT id FROM users WHERE`)

Fixes #6

🤖 Generated with [Claude Code](https://claude.ai/code)