### PR TITLE
Remove always false parts like 'OR false' from SQL simplification

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/RegularExpressions.Transformer.HasuraSQLSimplifier/issues/5
-Your prepared branch: issue-5-52c1af08
-Your prepared working directory: /tmp/gh-issue-solver-1757792399509
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/RegularExpressions.Transformer.HasuraSQLSimplifier/issues/5
+Your prepared branch: issue-5-52c1af08
+Your prepared working directory: /tmp/gh-issue-solver-1757792399509
+
+Proceed.

--- a/csharp/Platform.RegularExpressions.Transformer.HasuraSQLSimplifier.CLI/Platform.RegularExpressions.Transformer.HasuraSQLSimplifier.CLI.csproj
+++ b/csharp/Platform.RegularExpressions.Transformer.HasuraSQLSimplifier.CLI/Platform.RegularExpressions.Transformer.HasuraSQLSimplifier.CLI.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6</TargetFramework>
+    <TargetFramework>net8</TargetFramework>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>

--- a/csharp/Platform.RegularExpressions.Transformer.HasuraSQLSimplifier.Tests/HasuraSQLSimplifierTransformerTests.cs
+++ b/csharp/Platform.RegularExpressions.Transformer.HasuraSQLSimplifier.Tests/HasuraSQLSimplifierTransformerTests.cs
@@ -14,6 +14,37 @@ namespace Platform.RegularExpressions.Transformer.HasuraSQLSimplifier.Tests
         }
 
         [Fact]
+        public void RemoveOrFalseTest()
+        {
+            var transformer = new HasuraSQLSimplifierTransformer();
+            
+            // Test single OR 'false' removal
+            var input1 = "WHERE condition1 OR 'false'";
+            var expected1 = "WHERE condition1";
+            var actual1 = transformer.Transform(input1);
+            Assert.Equal(expected1, actual1);
+            
+            // Test OR ('false') with parentheses removal  
+            var input2 = "WHERE condition1 OR ('false')";
+            var expected2 = "WHERE condition1";
+            var actual2 = transformer.Transform(input2);
+            Assert.Equal(expected2, actual2);
+            
+            // Test OR ('false' OR 'false') removal
+            var input3 = "WHERE condition1 OR ('false' OR 'false')";
+            var expected3 = "WHERE condition1";
+            var actual3 = transformer.Transform(input3);
+            Assert.Equal(expected3, actual3);
+            
+            // Test with whitespace and newlines
+            var input4 = @"WHERE condition1 
+                OR   'false'";
+            var expected4 = @"WHERE condition1";
+            var actual4 = transformer.Transform(input4);
+            Assert.Equal(expected4, actual4);
+        }
+
+        [Fact]
         public void BasicRequestTest()
         {
             var original = @"SELECT

--- a/csharp/Platform.RegularExpressions.Transformer.HasuraSQLSimplifier/HasuraSQLSimplifierTransformer.cs
+++ b/csharp/Platform.RegularExpressions.Transformer.HasuraSQLSimplifier/HasuraSQLSimplifierTransformer.cs
@@ -34,6 +34,12 @@ namespace Platform.RegularExpressions.Transformer.HasuraSQLSimplifier
             // AND ('true')
             // 
             (new Regex(@"[\s\n]*AND[\s\n]*'true'"), "", 0),
+            // OR ('false' OR 'false')
+            //
+            (new Regex(@"[\s\n]*OR[\s\n]*\([\s\n]*'false'[\s\n]*OR[\s\n]*'false'[\s\n]*\)"), "", 0),
+            // OR ('false')
+            // 
+            (new Regex(@"[\s\n]*OR[\s\n]*'false'"), "", 0),
             //  :: 
             // ::
             (new Regex(@"[\s]*::[\s]*"), "::", 0),


### PR DESCRIPTION
## Summary
- Implement removal of always false SQL patterns like `OR 'false'` and `OR ('false' OR 'false')`
- Add comprehensive test cases to verify the new functionality works correctly
- Fix CLI project target framework compatibility issue (net6 → net8)

## Changes Made
- Added regex rules in `HasuraSQLSimplifierTransformer.cs`:39-42 to handle false pattern removal
- Added `RemoveOrFalseTest()` method with multiple test scenarios
- Updated CLI project target framework for consistency

## Test Plan
- [x] All existing tests pass
- [x] New test cases cover various OR false scenarios:
  - Basic `OR 'false'` removal
  - Parenthesized `OR ('false')` removal  
  - Nested `OR ('false' OR 'false')` removal
  - Whitespace and newline handling
- [x] Target framework compatibility verified

Resolves issue #5

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #5