### PR TITLE
Rename repository from RegularExpressions.Transformer.HasuraSQLSimplifier to RegularExpressions.Transformer.SQL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/RegularExpressions.Transformer.HasuraSQLSimplifier/issues/3
-Your prepared branch: issue-3-7feb9c3d
-Your prepared working directory: /tmp/gh-issue-solver-1757792711057
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/RegularExpressions.Transformer.HasuraSQLSimplifier/issues/3
+Your prepared branch: issue-3-7feb9c3d
+Your prepared working directory: /tmp/gh-issue-solver-1757792711057
+
+Proceed.

--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
-[![NuGet Version and Downloads count](https://img.shields.io/nuget/v/Platform.RegularExpressions.Transformer.HasuraSQLSimplifier?label=nuget&style=flat)](https://www.nuget.org/packages/Platform.RegularExpressions.Transformer.HasuraSQLSimplifier)
-[![Actions Status](https://github.com/linksplatform/RegularExpressions.Transformer.HasuraSQLSimplifier/workflows/CD/badge.svg)](https://github.com/linksplatform/RegularExpressions.Transformer.HasuraSQLSimplifier/actions?workflow=CD)
-[![Codacy Badge](https://app.codacy.com/project/badge/Grade/e48d26edaaa340c6b89c606cdd2d018e)](https://www.codacy.com/gh/linksplatform/RegularExpressions.Transformer.HasuraSQLSimplifier/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=linksplatform/RegularExpressions.Transformer.HasuraSQLSimplifier&amp;utm_campaign=Badge_Grade)
-[![CodeFactor](https://www.codefactor.io/repository/github/linksplatform/RegularExpressions.Transformer.HasuraSQLSimplifier/badge)](https://www.codefactor.io/repository/github/linksplatform/RegularExpressions.Transformer.HasuraSQLSimplifier)
+[![NuGet Version and Downloads count](https://img.shields.io/nuget/v/Platform.RegularExpressions.Transformer.SQL?label=nuget&style=flat)](https://www.nuget.org/packages/Platform.RegularExpressions.Transformer.SQL)
+[![Actions Status](https://github.com/linksplatform/RegularExpressions.Transformer.SQL/workflows/CD/badge.svg)](https://github.com/linksplatform/RegularExpressions.Transformer.SQL/actions?workflow=CD)
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/e48d26edaaa340c6b89c606cdd2d018e)](https://www.codacy.com/gh/linksplatform/RegularExpressions.Transformer.SQL/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=linksplatform/RegularExpressions.Transformer.SQL&amp;utm_campaign=Badge_Grade)
+[![CodeFactor](https://www.codefactor.io/repository/github/linksplatform/RegularExpressions.Transformer.SQL/badge)](https://www.codefactor.io/repository/github/linksplatform/RegularExpressions.Transformer.SQL)
 
-# [HasuraSQLSimplifier](https://github.com/linksplatform/HasuraSQLSimplifier)
+# [SQL](https://github.com/linksplatform/RegularExpressions.Transformer.SQL)
 
-LinksPlatform's Platform.RegularExpressions.Transformer.HasuraSQLSimplifier Class Library.
+LinksPlatform's Platform.RegularExpressions.Transformer.SQL Class Library.
 
-Namespace: [Platform.RegularExpressions.Transformer.HasuraSQLSimplifier](https://linksplatform.github.io/RegularExpressions.Transformer.HasuraSQLSimplifier/csharp/api/Platform.RegularExpressions.Transformer.HasuraSQLSimplifier.html)
+Namespace: [Platform.RegularExpressions.Transformer.SQL](https://linksplatform.github.io/RegularExpressions.Transformer.SQL/csharp/api/Platform.RegularExpressions.Transformer.SQL.html)
 
-NuGet package: [Platform.RegularExpressions.Transformer.HasuraSQLSimplifier](https://www.nuget.org/packages/Platform.RegularExpressions.Transformer.HasuraSQLSimplifier)
+NuGet package: [Platform.RegularExpressions.Transformer.SQL](https://www.nuget.org/packages/Platform.RegularExpressions.Transformer.SQL)
 
-## [Documentation](https://linksplatform.github.io/RegularExpressions.Transformer.HasuraSQLSimplifier)
-[PDF file](https://linksplatform.github.io/RegularExpressions.Transformer.HasuraSQLSimplifier/csharp/Platform.RegularExpressions.Transformer.HasuraSQLSimplifier.pdf) with code for e-readers.
+## [Documentation](https://linksplatform.github.io/RegularExpressions.Transformer.SQL)
+[PDF file](https://linksplatform.github.io/RegularExpressions.Transformer.SQL/csharp/Platform.RegularExpressions.Transformer.SQL.pdf) with code for e-readers.
 
 ## Build CLI tool
 
 ```
-cd csharp\Platform.RegularExpressions.Transformer.HasuraSQLSimplifier.CLI
+cd csharp\Platform.RegularExpressions.Transformer.SQL.CLI
 dotnet publish -c Release --runtime win10-x64 --self-contained true -p:PublishSingleFile=true
 ```
 

--- a/csharp/Platform.RegularExpressions.Transformer.SQL.CLI/Platform.RegularExpressions.Transformer.SQL.CLI.csproj
+++ b/csharp/Platform.RegularExpressions.Transformer.SQL.CLI/Platform.RegularExpressions.Transformer.SQL.CLI.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6</TargetFramework>
+    <TargetFramework>net8</TargetFramework>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Platform.RegularExpressions.Transformer.HasuraSQLSimplifier\Platform.RegularExpressions.Transformer.HasuraSQLSimplifier.csproj" />
+    <ProjectReference Include="..\Platform.RegularExpressions.Transformer.SQL\Platform.RegularExpressions.Transformer.SQL.csproj" />
   </ItemGroup>
 
 </Project>

--- a/csharp/Platform.RegularExpressions.Transformer.SQL.CLI/Program.cs
+++ b/csharp/Platform.RegularExpressions.Transformer.SQL.CLI/Program.cs
@@ -1,7 +1,7 @@
 using System;
 using Platform.Collections.Arrays;
 
-namespace Platform.RegularExpressions.Transformer.HasuraSQLSimplifier.CLI
+namespace Platform.RegularExpressions.Transformer.SQL.CLI
 {
     class Program
     {
@@ -22,7 +22,7 @@ namespace Platform.RegularExpressions.Transformer.HasuraSQLSimplifier.CLI
         {
             var sourceFileExtension = GetSourceFileExtension(args);
             var targetFileExtension = GetTargetFileExtension(args);
-            var simplifier = new HasuraSQLSimplifierTransformer();
+            var simplifier = new SQLTransformer();
             var transformer = IsDebugModeRequested(args) ? new LoggingFileTransformer(simplifier, sourceFileExtension, targetFileExtension) : new FileTransformer(simplifier, sourceFileExtension, targetFileExtension);
             new TransformerCLI(transformer).Run(args);
         }

--- a/csharp/Platform.RegularExpressions.Transformer.SQL.Tests/Platform.RegularExpressions.Transformer.SQL.Tests.csproj
+++ b/csharp/Platform.RegularExpressions.Transformer.SQL.Tests/Platform.RegularExpressions.Transformer.SQL.Tests.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Platform.RegularExpressions.Transformer.HasuraSQLSimplifier\Platform.RegularExpressions.Transformer.HasuraSQLSimplifier.csproj" />
+    <ProjectReference Include="..\Platform.RegularExpressions.Transformer.SQL\Platform.RegularExpressions.Transformer.SQL.csproj" />
   </ItemGroup>
 
 </Project>

--- a/csharp/Platform.RegularExpressions.Transformer.SQL.Tests/SQLTransformerTests.cs
+++ b/csharp/Platform.RegularExpressions.Transformer.SQL.Tests/SQLTransformerTests.cs
@@ -1,14 +1,14 @@
 using Xunit;
 
-namespace Platform.RegularExpressions.Transformer.HasuraSQLSimplifier.Tests
+namespace Platform.RegularExpressions.Transformer.SQL.Tests
 {
-    public class HasuraSQLSimplifierTransformerTests
+    public class SQLTransformerTests
     {
         [Fact]
         public void EmptyLineTest()
         {
             // This test can help to test basic problems with regular expressions like incorrect syntax
-            var transformer = new HasuraSQLSimplifierTransformer();
+            var transformer = new SQLTransformer();
             var actualResult = transformer.Transform("");
             Assert.Equal("", actualResult);
         }
@@ -124,7 +124,7 @@ FROM
       ) AS ""_1_root.base""
     LIMIT 1
   ) AS ""_3_root""";
-            var transformer = new HasuraSQLSimplifierTransformer();
+            var transformer = new SQLTransformer();
             var actual = transformer.Transform(original);
             Assert.Equal(expected, actual);
         }

--- a/csharp/Platform.RegularExpressions.Transformer.SQL.sln
+++ b/csharp/Platform.RegularExpressions.Transformer.SQL.sln
@@ -3,11 +3,11 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30517.126
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Platform.RegularExpressions.Transformer.HasuraSQLSimplifier", "Platform.RegularExpressions.Transformer.HasuraSQLSimplifier\Platform.RegularExpressions.Transformer.HasuraSQLSimplifier.csproj", "{00A15FCD-94B8-41DD-9747-B7958EDC841F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Platform.RegularExpressions.Transformer.SQL", "Platform.RegularExpressions.Transformer.SQL\Platform.RegularExpressions.Transformer.SQL.csproj", "{00A15FCD-94B8-41DD-9747-B7958EDC841F}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Platform.RegularExpressions.Transformer.HasuraSQLSimplifier.Tests", "Platform.RegularExpressions.Transformer.HasuraSQLSimplifier.Tests\Platform.RegularExpressions.Transformer.HasuraSQLSimplifier.Tests.csproj", "{003589B4-670D-470F-AE2B-3E5DBA0B3C0C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Platform.RegularExpressions.Transformer.SQL.Tests", "Platform.RegularExpressions.Transformer.SQL.Tests\Platform.RegularExpressions.Transformer.SQL.Tests.csproj", "{003589B4-670D-470F-AE2B-3E5DBA0B3C0C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Platform.RegularExpressions.Transformer.HasuraSQLSimplifier.CLI", "Platform.RegularExpressions.Transformer.HasuraSQLSimplifier.CLI\Platform.RegularExpressions.Transformer.HasuraSQLSimplifier.CLI.csproj", "{1EBEB2FB-56D5-4F1F-9646-AD70F1A35A89}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Platform.RegularExpressions.Transformer.SQL.CLI", "Platform.RegularExpressions.Transformer.SQL.CLI\Platform.RegularExpressions.Transformer.SQL.CLI.csproj", "{1EBEB2FB-56D5-4F1F-9646-AD70F1A35A89}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/csharp/Platform.RegularExpressions.Transformer.SQL/Platform.RegularExpressions.Transformer.SQL.csproj
+++ b/csharp/Platform.RegularExpressions.Transformer.SQL/Platform.RegularExpressions.Transformer.SQL.csproj
@@ -1,20 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Description>LinksPlatform's Platform.RegularExpressions.Transformer.HasuraSQLSimplifier Class Library</Description>
+    <Description>LinksPlatform's Platform.RegularExpressions.Transformer.SQL Class Library</Description>
     <Copyright>Konstantin Diachenko</Copyright>
-    <AssemblyTitle>Platform.RegularExpressions.Transformer.HasuraSQLSimplifier</AssemblyTitle>
+    <AssemblyTitle>Platform.RegularExpressions.Transformer.SQL</AssemblyTitle>
     <VersionPrefix>0.0.2</VersionPrefix>
     <Authors>Konstantin Diachenko</Authors>
     <TargetFramework>net8</TargetFramework>
-    <AssemblyName>Platform.RegularExpressions.Transformer.HasuraSQLSimplifier</AssemblyName>
-    <PackageId>Platform.RegularExpressions.Transformer.HasuraSQLSimplifier</PackageId>
-    <PackageTags>LinksPlatform;RegularExpressions.Transformer.HasuraSQLSimplifier;HasuraSQLSimplifierTransformer</PackageTags>
+    <AssemblyName>Platform.RegularExpressions.Transformer.SQL</AssemblyName>
+    <PackageId>Platform.RegularExpressions.Transformer.SQL</PackageId>
+    <PackageTags>LinksPlatform;RegularExpressions.Transformer.SQL;SQLTransformer</PackageTags>
     <PackageIconUrl>https://raw.githubusercontent.com/linksplatform/Documentation/18469f4d033ee9a5b7b84caab9c585acab2ac519/doc/Avatar-rainbow-icon-64x64.png</PackageIconUrl>
-    <PackageProjectUrl>https://linksplatform.github.io/RegularExpressions.Transformer.HasuraSQLSimplifier</PackageProjectUrl>
+    <PackageProjectUrl>https://linksplatform.github.io/RegularExpressions.Transformer.SQL</PackageProjectUrl>
     <PackageLicenseExpression>Unlicensed</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>git://github.com/linksplatform/HasuraSQLSimplifier</RepositoryUrl>
+    <RepositoryUrl>git://github.com/linksplatform/RegularExpressions.Transformer.SQL</RepositoryUrl>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/csharp/Platform.RegularExpressions.Transformer.SQL/SQLTransformer.cs
+++ b/csharp/Platform.RegularExpressions.Transformer.SQL/SQLTransformer.cs
@@ -4,16 +4,16 @@ using System.Text.RegularExpressions;
 
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 
-namespace Platform.RegularExpressions.Transformer.HasuraSQLSimplifier
+namespace Platform.RegularExpressions.Transformer.SQL
 {
     /// <summary>
     /// <para>
-    /// Represents the hasura sql simplifier transformer.
+    /// Represents the SQL transformer.
     /// </para>
     /// <para></para>
     /// </summary>
     /// <seealso cref="TextTransformer"/>
-    public class HasuraSQLSimplifierTransformer : TextTransformer
+    public class SQLTransformer : TextTransformer
     {
         /// <summary>
         /// <para>
@@ -62,11 +62,11 @@ namespace Platform.RegularExpressions.Transformer.HasuraSQLSimplifier
 
         /// <summary>
         /// <para>
-        /// Initializes a new <see cref="HasuraSQLSimplifierTransformer"/> instance.
+        /// Initializes a new <see cref="SQLTransformer"/> instance.
         /// </para>
         /// <para></para>
         /// </summary>
-        public HasuraSQLSimplifierTransformer()
+        public SQLTransformer()
             : base(DefaultRules)
         {
         }


### PR DESCRIPTION
## Summary
This pull request implements the repository rename requested in issue #3. It renames the repository from `RegularExpressions.Transformer.HasuraSQLSimplifier` to `RegularExpressions.Transformer.SQL`.

### Changes Made:
- ✅ Renamed all project directories and files from `HasuraSQLSimplifier` to `SQL`
- ✅ Updated namespace from `Platform.RegularExpressions.Transformer.HasuraSQLSimplifier` to `Platform.RegularExpressions.Transformer.SQL`  
- ✅ Renamed class `HasuraSQLSimplifierTransformer` to `SQLTransformer`
- ✅ Updated all project references and dependencies to use new names
- ✅ Updated NuGet package metadata (PackageId, AssemblyName, etc.)
- ✅ Updated README badges and documentation links to use new repository name
- ✅ Fixed CLI project target framework from net6 to net8 for compatibility

## Test Plan
- ✅ All projects build successfully with `dotnet build`
- ✅ All unit tests pass with `dotnet test`
- ✅ Solution compiles without warnings or errors
- ✅ CLI functionality preserved (class rename from `HasuraSQLSimplifierTransformer` to `SQLTransformer`)

## Notes
The rename is comprehensive and includes:
- File and directory names
- Namespaces and class names
- Project references
- Package metadata
- Documentation and links

All functionality is preserved - only naming has changed from "HasuraSQLSimplifier" to "SQL" throughout the codebase.

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #3